### PR TITLE
[Hotfix] added alternate JSC command path for MacOSv10.15

### DIFF
--- a/lib/execjs/runtimes.rb
+++ b/lib/execjs/runtimes.rb
@@ -27,7 +27,10 @@ module ExecJS
 
     JavaScriptCore = ExternalRuntime.new(
       name:        "JavaScriptCore",
-      command:     "/System/Library/Frameworks/JavaScriptCore.framework/Versions/A/Resources/jsc",
+      command:     [
+        "/System/Library/Frameworks/JavaScriptCore.framework/Versions/A/Resources/jsc",
+        "/System/Library/Frameworks/JavaScriptCore.framework/Versions/A/Helpers/jsc"
+      ],
       runner_path: ExecJS.root + "/support/jsc_runner.js"
     )
 


### PR DESCRIPTION
In MacOS v10.15 Catalina, JSC command path changed from `/System/Library/Frameworks/JavaScriptCore.framework/Versions/A/Resources/` to `/System/Library/Frameworks/JavaScriptCore.framework/Versions/A/Helpers/`.

Added the updated path along with the existing for the JSC command.